### PR TITLE
Add a simple pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    "numpy"
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Hi devs, thank you for maintaining this package! The following is short MR that seems to simplify the installation process.

This MR  makes it possible to specify `wheel` and `numpy `as build dependencies (in `pyproject.toml`)  so that they are installed by pip, *before* the stuff in `setup.py` is run. Thus one can simply do

`pip install .`

without worrying about installing `wheel` and `numpy` first. 

 This is helpful when one lists `pygsl` as a requirement and it is being built in a clean environment where `numpy` might not be installed at the time that `pygsl` is built.