### PR TITLE
Pin setuptools to avoid problems with numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools",
+    "setuptools==64.0.0",
     "wheel",
     "numpy"
 ]


### PR DESCRIPTION
The newest `setuptools` causes `numpy` to have problems:

```
Traceback (most recent call last):
File "/private/var/folders/zp/8xlv2c_x0vx_h96lr3tvsrlr0000gn/T/pip-build-env-915q4nap/overlay/lib/python3.9/site-packages/numpy/distutils/log.py", line 4, in <module>
      ImportError: cannot import name 'Log' from 'distutils.log' (/private/var/folders/zp/8xlv2c_x0vx_h96lr3tvsrlr0000gn/T/pip-build-env-915q4nap/overlay/lib/python3.9/site-packages/setuptools/_distutils/log.py)
```
This PR pins `setuptools` until the issue is resolved.