### PR TITLE
Require SWIG for installation

### DIFF
--- a/.github/workflows/pygsl-ci.yml
+++ b/.github/workflows/pygsl-ci.yml
@@ -11,20 +11,20 @@ jobs:
     steps:
       # Checkout the repository contents
       - name: Checkout PyGSL code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Setup Python version
       - name: Setup Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
       # Install dependencies
       - name: Install apt dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install libgsl0-dev libncurses5-dev libreadline6-dev pkg-config
-          sudo apt-get install python3-all-dev python3-matplotlib python3-numpy python3-scipy
+          sudo apt update
+          sudo apt install libgsl0-dev libncurses5-dev libreadline6-dev pkg-config swig
+          sudo apt install python3-all-dev python3-matplotlib python3-numpy python3-scipy
 
       # Install Python dependencies
       - name: Python dependencies
@@ -51,55 +51,8 @@ jobs:
           cd /tmp
           python -m pytest -s /home/runner/work/pygsl/pygsl/tests
 
-  build:
-    # Build and test only, use pre-generated SWIG wrappers
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-
-    steps:
-      # Checkout the repository contents
-      - name: Checkout PyGSL code
-        uses: actions/checkout@v2
-
-      # Setup Python version
-      - name: Setup Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-
-      # Install dependencies
-      - name: Install apt dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install libgsl0-dev libncurses5-dev libreadline6-dev pkg-config
-          sudo apt-get install python3-all-dev python3-matplotlib python3-numpy python3-scipy
-          sudo apt remove --yes --purge "^swig.*"
-
-      # Install Python dependencies
-      - name: Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install pytest numpy scipy matplotlib
-          python -m pip install pycodestyle
-          python -m pip install wheel setuptools --upgrade
-
-      - name: config
-        run: |
-          python setup.py config
-
-      - name: install
-        run: |
-          python setup.py install
-
-      - name: test
-        run: |
-          # make sure to move out of the source directory
-          cd /tmp
-          python -m pytest -s /home/runner/work/pygsl/pygsl/tests
-
   build_whl:
-    # Build and test only, use pre-generated SWIG wrappers
+    # Build a Python wheel file and install from the wheel
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -107,21 +60,20 @@ jobs:
     steps:
       # Checkout the repository contents
       - name: Checkout PyGSL code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Setup Python version
       - name: Setup Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
       # Install dependencies
       - name: Install apt dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install libgsl0-dev libncurses5-dev libreadline6-dev pkg-config
-          sudo apt-get install python3-all-dev python3-matplotlib python3-numpy python3-scipy
-          sudo apt remove --yes --purge "^swig.*"
+          sudo apt update
+          sudo apt install libgsl0-dev libncurses5-dev libreadline6-dev pkg-config swig
+          sudo apt install python3-all-dev python3-matplotlib python3-numpy python3-scipy
 
       # Install Python dependencies
       - name: Python dependencies
@@ -130,6 +82,10 @@ jobs:
           python -m pip install pytest numpy scipy matplotlib
           python -m pip install pycodestyle
           python -m pip install wheel setuptools --upgrade
+
+      - name: gsl_wrappers
+        run: |
+          python setup.py gsl_wrappers
 
       - name: config
         run: |

--- a/.github/workflows/pygsl-pypi.yml
+++ b/.github/workflows/pygsl-pypi.yml
@@ -1,3 +1,4 @@
+
 name: PyGSL from PyPI
 on:
   schedule:
@@ -22,21 +23,20 @@ jobs:
     steps:
       # Checkout the repository contents
       - name: Checkout PyGSL code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Setup Python version
       - name: Setup Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
       # Install dependencies
       - name: Install apt dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install libgsl0-dev libncurses5-dev libreadline6-dev pkg-config
-          sudo apt-get install python3-all-dev python3-matplotlib python3-numpy python3-scipy
-          sudo apt remove --yes --purge "^swig.*"
+          sudo apt update
+          sudo apt install libgsl0-dev libncurses5-dev libreadline6-dev pkg-config swig
+          sudo apt install python3-all-dev python3-matplotlib python3-numpy python3-scipy
 
       # Install Python dependencies
       - name: Python dependencies

--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,7 @@ You can download a ``.tar.gz`` file of the latest PyGSL release at https://githu
 
    tar -xvzf pygsl-x.y.z.tar.gz
    cd pygsl-x.y.z
+   python setup.py gsl_wrappers
    python setup.py config
    sudo python setup.py install
 
@@ -55,7 +56,9 @@ PyGSL is installed to the Python packages path, and can be uninstalled by typing
 Installation via PyPI
 ~~~~~~~~~~~~~~~~~~~~~
 
-PyGSL can also be installed using the pip package installer. Simply type:
+PyGSL can also be installed using the pip package installer. SWIG is required to be installed and can usually be found via your distribution's package manager (for example, ``apt install swig``).
+
+To install PyGSL from PyPI, simply type:
 
 .. code-block:: sh
 
@@ -67,17 +70,6 @@ To remove PyGSL, use:
 
    pip uninstall pygsl
    
-Development installation
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-Pre-generated SWIG wrappers are included in the PyGSL release. To re-generate these wrappers, run:
-
-.. code-block:: sh
-
-   python setup.py gsl_wrappers
-
-then continue with the rest of the installation steps (``config``, ``install``).
-
 Using PyGSL
 -----------
 
@@ -116,7 +108,7 @@ but is supposed to compile and run on any posix platform.
 
 Currently it is being tested using GitHub Actions continuous integration on:
 
-- Python 3.8, numpy-latest and GSL 2.5 under Ubuntu Linux 20.04.
+- Python 3.8, numpy-latest and GSL 2.7.1 under Ubuntu Linux 22.04.2.
 
 
 Testing


### PR DESCRIPTION
Always re-generate the wrappers with SWIG for any install (including from PyPI).

TODO
- [ ] add CI test for GSL 2.5 (necessary?)