### PR TITLE
Fix test error with python 3.12

### DIFF
--- a/tests/run_test.py
+++ b/tests/run_test.py
@@ -13,7 +13,7 @@ def run_file_posix(file):
         #print "Executing child %d" % os.getpid()
         absfile = os.path.abspath(file)
         print("Executing file %s %s" % (sys.executable,  absfile))
-        os.execl(sys.executable, "", absfile)
+        os.execl(sys.executable, sys.executable, absfile)
         #print "Exit status of %s is %d" % (absfile, flag)
         #sys.exit(flag)
 	
@@ -23,7 +23,7 @@ def run_file_posix(file):
         cpid, status = os.waitpid(pid, os.P_WAIT)
         assert(cpid == pid)
         if os.WIFSIGNALED(status):
-            print("Recieved signal when executing file %s, status %d" % (file, status))
+            print("Received signal when executing file %s, status %d" % (file, status))
         return
     elif pid < 0:
         print("Fork error!")


### PR DESCRIPTION
With python 3.12rc1, the tests fail like this:
```
Executing file /usr/bin/python3 /builddir/build/BUILD/pygsl-2.3.3/tests/blas_test.py
Traceback (most recent call last):
  File "/builddir/build/BUILD/pygsl-2.3.3/tests/run_test.py", line 68, in <module>
    run()
  File "/builddir/build/BUILD/pygsl-2.3.3/tests/run_test.py", line 65, in run
    run_file(path)
  File "/builddir/build/BUILD/pygsl-2.3.3/tests/run_test.py", line 16, in run_file_posix
    os.execl(sys.executable, "", absfile)
  File "<frozen os>", line 548, in execl
ValueError: execv() arg 2 first element cannot be empty
```

Since `argv[0]` is typically the name of the executable, use that instead of the empty string.

I also fixed a typo while I was modifying this file.