### PR TITLE
Convert strings with escapes to raw strings

### DIFF
--- a/gsl_dist/gsl_Location.py
+++ b/gsl_dist/gsl_Location.py
@@ -60,7 +60,7 @@ class _gsl_Location:
         def _split_version(self, version):
                 if version[-1] == '+':
                         version = version[:-1]
-                return re.split('\.',version)
+                return re.split(r'\.',version)
 
         def get_swig(self):
                 assert(self.swig)

--- a/pygsl/blas.py
+++ b/pygsl/blas.py
@@ -42,49 +42,49 @@ gsl_blas_sdsdot = gslwrap.gsl_blas_sdsdot
 #
 
 def ddot(x, y):
-    """This function computes the scalar product \M{x^T y} for the vectors x and y,
+    r"""This function computes the scalar product \M{x^T y} for the vectors x and y,
     returning the result. 
     """
     return _gslwrap.gsl_blas_ddot(x, y)#[1]
 
 
 def zdotu(x, y):
-    """This function computes the complex scalar product \M{x^T y} for the
+    r"""This function computes the complex scalar product \M{x^T y} for the
     vectors x and y, returning the result.
     """
     return _gslwrap.gsl_blas_zdotu(x, y, 1j)#[1]
 
 
 def zdotc(x, y):
-    """This function computes the complex conjugate scalar product \M{x^H y} for the
+    r"""This function computes the complex conjugate scalar product \M{x^H y} for the
     vectors x and y, returning the result. 
     """
     return _gslwrap.gsl_blas_zdotc(x, y, 1j)#[1]
 
 
 def dnrm2(x):
-    """This function computes the Euclidean norm \M{||x||_2 = \sqrt {\sum x_i^2}}
+    r"""This function computes the Euclidean norm \M{||x||_2 = \sqrt {\sum x_i^2}}
     of the vector x. 
     """
     return _gslwrap.gsl_blas_dnrm2(x)
 
 
 def dznrm2(x):
-    """This function computes the Euclidean norm of the complex vector x,
+    r"""This function computes the Euclidean norm of the complex vector x,
     \M{||x||_2 = \sqrt {\sum (\Re(x_i)^2 + \Im(x_i)^2)}}.
     """
     return _gslwrap.gsl_blas_dznrm2(x)
 
 
 def dasum(x):
-    """This function computes the absolute sum \M{\sum |x_i|} of the elements
+    r"""This function computes the absolute sum \M{\sum |x_i|} of the elements
     of the vector x. 
     """
     return _gslwrap.gsl_blas_dasum(x)
 
 
 def dzasum(x):
-    """This function computes the absolute sum \M{\sum |\Re(x_i)| + |\Im(x_i)|}
+    r"""This function computes the absolute sum \M{\sum |\Re(x_i)| + |\Im(x_i)|}
     of the elements of the vector x. 
     """
     return _gslwrap.gsl_blas_dzasum(x)
@@ -100,7 +100,7 @@ def idamax(x):
 
 
 def izamax(x):
-    """This function returns the index of the largest element of the vector x.
+    r"""This function returns the index of the largest element of the vector x.
     The largest element is determined by the sum of the magnitudes of the
     real and imaginary parts \M{|\Re(x_i)| + |\Im(x_i)|}. If the largest value
     occurs several times then the index of the first occurrence is returned. 
@@ -109,7 +109,7 @@ def izamax(x):
 
 
 def daxpy(alpha, x, y):
-    """This function computes the sum \M{y = S{alpha} x + y} for the vectors x and y.
+    r"""This function computes the sum \M{y = S{alpha} x + y} for the vectors x and y.
     """
     yn = array_typed_copy(y, Float)
     _gslwrap.gsl_blas_daxpy(alpha, x, yn)
@@ -117,13 +117,13 @@ def daxpy(alpha, x, y):
 
 
 def daxpy_cr(alpha, x, y_CR):
-    """This function computes the sum \M{y = S{alpha} x + y} for the vectors x and y.
+    r"""This function computes the sum \M{y = S{alpha} x + y} for the vectors x and y.
     """
     _gslwrap.gsl_blas_daxpy(alpha, x, y_CR)
     
 
 def zaxpy(alpha, x, y):
-    """This function computes the sum \M{y = S{alpha} x + y} for the vectors x and y.
+    r"""This function computes the sum \M{y = S{alpha} x + y} for the vectors x and y.
     """
     yn = array_typed_copy(y, Complex)
     _gslwrap.gsl_blas_zaxpy(alpha, x, yn)
@@ -131,13 +131,13 @@ def zaxpy(alpha, x, y):
 
 
 def zaxpy_cr(alpha, x, y_CR):
-    """This function computes the sum \M{y = S{alpha} x + y} for the vectors x and y.
+    r"""This function computes the sum \M{y = S{alpha} x + y} for the vectors x and y.
     """
     _gslwrap.gsl_blas_zaxpy(alpha, x, y_CR)
  
 
 def drot(x, y, c, s):
-    """This function applies a Givens rotation \M{(x', y') = (c x + s y, -s x + c y)}
+    r"""This function applies a Givens rotation \M{(x', y') = (c x + s y, -s x + c y)}
     to the vectors x, y.
     """
     xn = array_typed_copy(x, Float)
@@ -147,7 +147,7 @@ def drot(x, y, c, s):
 
 
 def drot_cr(x_CR, y_CR, c, s):
-    """This function applies a Givens rotation \M{(x', y') = (c x + s y, -s x + c y)}
+    r"""This function applies a Givens rotation \M{(x', y') = (c x + s y, -s x + c y)}
     to the vectors x, y.
     """
     _gslwrap.gsl_blas_drot(x_CR, y_CR, c, s)
@@ -158,7 +158,7 @@ def drot_cr(x_CR, y_CR, c, s):
 #
 
 def dgemv(alpha, a, x, beta, y, TransA=CblasNoTrans):
-    """This function computes the matrix-vector product and
+    r"""This function computes the matrix-vector product and
     sum \M{y = S{alpha} op(A) x + S{beta} y}, where op(A) = \M{A, A^T, A^H} for
     TransA = CblasNoTrans, CblasTrans, CblasConjTrans.
     """
@@ -168,7 +168,7 @@ def dgemv(alpha, a, x, beta, y, TransA=CblasNoTrans):
     
 
 def zgemv(alpha, a, x, beta, y, TransA=CblasNoTrans):
-    """This function computes the matrix-vector product and
+    r"""This function computes the matrix-vector product and
     sum \M{y = S{alpha} op(A) x + S{beta} y}, where \M{op(A) = A, A^T, A^H} for
     TransA = CblasNoTrans, CblasTrans, CblasConjTrans.
     """
@@ -269,7 +269,7 @@ def ztrsv(A,
 
 
 def dsymv(alpha, A, X, beta, Y, Uplo=CblasLower):
-    """
+    r"""
     returns y'
 
     This function computes the matrix-vector product and
@@ -285,7 +285,7 @@ def dsymv(alpha, A, X, beta, Y, Uplo=CblasLower):
 
 
 def zhemv(alpha, A, X, beta, Y, Uplo=CblasLower):
-    """
+    r"""
     returns y'
     
     This function computes the matrix-vector product and
@@ -302,7 +302,7 @@ def zhemv(alpha, A, X, beta, Y, Uplo=CblasLower):
 
 
 def dger(alpha, X, Y, A):
-    """
+    r"""
     returns A'
 
     This function computes the rank-1 update \M{A' = S{alpha} x y^T + A} of
@@ -314,7 +314,7 @@ def dger(alpha, X, Y, A):
 
 
 def zgeru(alpha, X, Y, A):
-    """
+    r"""
     returns A'
 
     This function computes the rank-1 update \M{A' = S{alpha} x y^T + A} of
@@ -326,7 +326,7 @@ def zgeru(alpha, X, Y, A):
 
 
 def zgerc(alpha, X, Y, A):
-    """
+    r"""
     returns A'
 
     This function computes the conjugate rank-1 update
@@ -338,7 +338,7 @@ def zgerc(alpha, X, Y, A):
 
 
 def dsyr(alpha, X, A, Uplo=CblasLower):
-    """
+    r"""
     returns A'
 
     This function computes the symmetric rank-1 update
@@ -354,7 +354,7 @@ def dsyr(alpha, X, A, Uplo=CblasLower):
 
 
 def zher(alpha, X, A, Uplo=CblasLower):
-    """
+    r"""
     returns A'
 
     This function computes the hermitian rank-1 update
@@ -371,7 +371,7 @@ def zher(alpha, X, A, Uplo=CblasLower):
 
 
 def dsyr2(alpha, X, Y, A, Uplo=CblasLower):
-    """
+    r"""
     returns A'
 
     This function computes the symmetric rank-2 update
@@ -387,7 +387,7 @@ def dsyr2(alpha, X, Y, A, Uplo=CblasLower):
 
 
 def zher2(alpha, X, Y, A, Uplo=CblasLower):
-    """
+    r"""
     returns A'
 
     This function computes the hermitian rank-2 update
@@ -412,7 +412,7 @@ def dgemm(alpha,
           beta, C,
           TransA=CblasNoTrans,
           TransB=CblasNoTrans):
-    """
+    r"""
     returns C'
     
     This function computes the matrix-matrix product and sum
@@ -430,7 +430,7 @@ def zgemm(alpha,
           beta, C,
           TransA=CblasNoTrans,
           TransB=CblasNoTrans):
-    """
+    r"""
     returns C'
     
     This function computes the matrix-matrix product and sum
@@ -446,7 +446,7 @@ def zgemm(alpha,
 def dsymm(alpha, A, B, beta, C,
           Side=CblasLeft,
           Uplo=CblasLower):
-    """
+    r"""
     returns C'
     
     This function computes the matrix-matrix product and
@@ -464,7 +464,7 @@ def dsymm(alpha, A, B, beta, C,
 def zsymm(alpha, A, B, beta, C,
           Side=CblasLeft,
           Uplo=CblasLower):
-    """
+    r"""
     returns C'
     
     This function computes the matrix-matrix product and
@@ -482,7 +482,7 @@ def zsymm(alpha, A, B, beta, C,
 def zhemm(alpha, A, B, beta, C,
           Side=CblasLeft,
           Uplo=CblasLower):
-    """
+    r"""
     returns C'
     
     This function computes the matrix-matrix product and
@@ -503,7 +503,7 @@ def dtrmm(alpha, A, B,
           Uplo=CblasLower,
           TransA=CblasNoTrans,
           Diag=CblasNonUnit):
-    """
+    r"""
     returns B'
 
     This function computes the matrix-matrix product
@@ -526,7 +526,7 @@ def ztrmm(alpha, A, B,
           Uplo=CblasLower,
           TransA=CblasNoTrans,
           Diag=CblasNonUnit):
-    """
+    r"""
     returns B'
 
     This function computes the matrix-matrix product
@@ -549,7 +549,7 @@ def dtrsm(alpha, A, B,
           Uplo=CblasLower,
           TransA=CblasNoTrans,
           Diag=CblasNonUnit):
-    """
+    r"""
     returns B'
     
     This function computes the matrix-matrix product
@@ -572,13 +572,13 @@ def ztrsm(alpha, A, B,
          Uplo=CblasLower,
          TransA=CblasNoTrans,
          Diag=CblasNonUnit):
-    """
+    r"""
     Returns:
           :math:`B'`
     
     This function computes the matrix-matrix product
     \M{B' = S{alpha} op(inv(A)) B} for Side is CblasLeft and
-   \M{ B' = S{alpha} B op(inv(A))} for Side is CblasRight. The matrix A is
+    \M{B' = S{alpha} B op(inv(A))} for Side is CblasRight. The matrix A is
     triangular and op(A) = A, A^T, A^H for TransA = CblasNoTrans,
     CblasTrans, CblasConjTrans When Uplo is CblasUpper then the upper
     triangle of A is used, and when Uplo is CblasLower then the lower
@@ -594,7 +594,7 @@ def ztrsm(alpha, A, B,
 def dsyrk(alpha, A, beta, C,
          Uplo=CblasLower,
          Trans=CblasNoTrans):
-    """
+    r"""
     returns C'
     
     This function computes a rank-k update of the symmetric matrix C,
@@ -613,7 +613,7 @@ def dsyrk(alpha, A, beta, C,
 def zsyrk(alpha, A, beta, C,
          Uplo=CblasLower,
          Trans=CblasNoTrans):
-    """
+    r"""
     returns C'
     
     This function computes a rank-k update of the symmetric matrix C,
@@ -684,7 +684,7 @@ def triang2herm(A,
 def zherk(alpha, A, beta, C,
           Uplo=CblasLower,
           Trans=CblasNoTrans):          
-    """
+    r"""
     returns C'
     
     This function computes a rank-k update of the hermitian matrix C,
@@ -704,7 +704,7 @@ def zherk(alpha, A, beta, C,
 def dsyr2k(alpha, A, B, beta, C,
           Uplo=CblasLower,
           Trans=CblasNoTrans):                     
-    """
+    r"""
     returns C'
     
     This function computes a rank-2k update of the symmetric
@@ -723,7 +723,7 @@ def dsyr2k(alpha, A, B, beta, C,
 def zsyr2k(alpha, A, B, beta, C,
           Uplo=CblasLower,
           Trans=CblasNoTrans):                     
-    """
+    r"""
     returns C'
     
     This function computes a rank-2k update of the symmetric
@@ -742,7 +742,7 @@ def zsyr2k(alpha, A, B, beta, C,
 def zher2k(alpha, A, B, beta, C,
           Uplo=CblasLower,
           Trans=CblasNoTrans):                     
-    """
+    r"""
     returns C'
     
     This function computes a rank-2k update of the hermitian matrix C,

--- a/pygsl/chebyshev.py
+++ b/pygsl/chebyshev.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Author : Pierre Schnizer 
-"""Chebyshev  approximation
+r"""Chebyshev  approximation
 
 This module describes routines for computing Chebyshev
 approximations to univariate functions.  A Chebyshev approximation is a
@@ -73,7 +73,7 @@ class cheb_series(_workspace):
         _workspace.__init__(self, size)
         
     def init(self, f, a, b):
-        """computes the Chebyshev approximation for the
+        r"""computes the Chebyshev approximation for the
         function F over the range (a,b) to the previously specified order.
 
         The computation of the Chebyshev approximation is an \M{O(n^2)}

--- a/pygsl/fit.py
+++ b/pygsl/fit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # Author : Pierre Schnizer <pierre.schnizer@helmholtz-berlin.de>
 #  Date  : January 2003, 2017
-"""
+r"""
 
 The functions described in this section can be used to perform
 least-squares fits to a straight line model, 
@@ -42,7 +42,7 @@ def linear(x, y):
     return _callback.gsl_fit_linear(x,y)
 
 def wlinear(x, y, w):
-    """Weighted linear fit
+    r"""Weighted linear fit
 
     Args:
          x ... independent data
@@ -116,7 +116,7 @@ def mul(x,y):
     return _callback.gsl_fit_mul(x,y)
 
 def wmul(x, y, w):
-    """compute weighted best linear regression (without abszissa)
+    r"""compute weighted best linear regression (without abszissa)
 
     Args:
          x: independent data

--- a/pygsl/integrate.py
+++ b/pygsl/integrate.py
@@ -47,7 +47,7 @@ class workspace(_workspace):
         return self._size(self._ptr)
 
 class qaws_table(_workspace):
-    """Integration table for qaws
+    r"""Integration table for qaws
 
     This class allocates space for a `gsl_integration_qaws_table'
     struct and associated workspace describing a singular weight
@@ -84,7 +84,7 @@ class qaws_table(_workspace):
         self._ptr = self._alloc(alpha, beta, mu, nu)
 
     def set(self, alpha, beta, mu, nu):
-        """
+        r"""
          This function modifies the parameters (\alpha, \beta, \mu, \nu)
 
          input : alpha, beta, mu, nu
@@ -93,7 +93,7 @@ class qaws_table(_workspace):
 
 
 class qawo_table(_workspace):
-    """Table for qawo
+    r"""Table for qawo
     
         This class manages space for a `qawo_table'
       and its associated workspace describing a sine or cosine
@@ -256,7 +256,7 @@ def qagp(f, pts, epsabs, epsrel, limit, workspace):
                                           workspace._ptr)
 
 def qagi(f, epsabs, epsrel, limit, workspace):
-    """
+    r"""
     This function computes the integral of the function F over the
      infinite interval (-\infty,+\infty).  The integral is mapped onto
      the interval (0,1] using the transformation x = (1-t)/t,
@@ -278,7 +278,7 @@ def qagi(f, epsabs, epsrel, limit, workspace):
                                             workspace._ptr)
 
 def qagiu(f, a, epsabs, epsrel, limit, workspace):
-    """
+    r"""
      This function computes the integral of the function F over the
      semi-infinite interval (a,+\infty).  The integral is mapped onto
      the interval (0,1] using the transformation x = a + (1-t)/t,
@@ -296,8 +296,8 @@ def qagiu(f, a, epsabs, epsrel, limit, workspace):
                                             workspace._ptr)
 
 def qagil(f, b, epsabs, epsrel, limit, workspace):
-    """
-    his function computes the integral of the function F over the
+    r"""
+    This function computes the integral of the function F over the
      semi-infinite interval (-\infty,b).  The integral is mapped onto
      the region (0,1] using the transformation x = b - (1-t)/t,
 
@@ -314,7 +314,7 @@ def qagil(f, b, epsabs, epsrel, limit, workspace):
                                             workspace._ptr)
 
 def qawc(f, a, b, c, epsabs, epsrel, limit, workspace):
-    """
+    r"""
      This function computes the Cauchy principal value of the integral
      of f over (a,b), with a singularity at C,
 
@@ -336,7 +336,7 @@ def qawc(f, a, b, c, epsabs, epsrel, limit, workspace):
                                             workspace._ptr)
 
 def qaws(f, a, b, qwas_table, epsabs, epsrel, limit, workspace):
-    """
+    r"""
     This function computes the integral of the function f(x) over the
      interval (a,b) with the singular weight function (x-a)^\alpha
      (b-x)^\beta \log^\mu (x-a) \log^\nu (b-x).  The parameters of the
@@ -361,7 +361,7 @@ def qaws(f, a, b, qwas_table, epsabs, epsrel, limit, workspace):
 
 
 def qawo(f, a, epsabs, epsrel, limit, workspace, qwao_table):
-    """
+    r"""
     This function uses an adaptive algorithm to compute the integral of
      f over (a,b) with the weight function \sin(\omega x) or
      \cos(\omega x) defined by the table WF.
@@ -392,7 +392,7 @@ def qawo(f, a, epsabs, epsrel, limit, workspace, qwao_table):
                                           workspace._ptr, qwao_table._ptr)
 
 def qawf(f, a, epsabs, limit, workspace, cycleworkspace, qwao_table):
-    """
+    r"""
         This function attempts to compute a Fourier integral of the
      function F over the semi-infinite interval [a,+\infty).
 

--- a/pygsl/linalg.py
+++ b/pygsl/linalg.py
@@ -154,7 +154,7 @@ def LU_det(LU, signum):
 
 
 def LU_lndet(LU):
-    """
+    r"""
     This function computes the logarithm of the absolute value of the
     determinant of a matrix A, \ln|det(A)|, from its LU decomposition, LU.
     This function may be useful if the direct computation of the determinant
@@ -188,7 +188,7 @@ def LU_sgndet(LU, signum):
 #
 
 def QR_decomp(A):
-    """
+    r"""
     returns (QR, tau)
 
     Function: int gsl_linalg_QR_decomp (gsl_matrix * A, gsl_vector * tau)

--- a/pygsl/minimize.py
+++ b/pygsl/minimize.py
@@ -129,7 +129,7 @@ class brent(_minsolver):
     type = _callback.cvar.gsl_min_fminimizer_brent
 
 class goldensection(_minsolver):
-    """
+    r"""
     The "golden section algorithm" is the simplest method of bracketing
     the minimum of a function.  It is the slowest algorithm provided
     by the library, with linear convergence.
@@ -153,7 +153,7 @@ class goldensection(_minsolver):
 
 
 def test_interval(x_lower, x_upper, epsabs, epsrel):
-    """
+    r"""
     This function tests for the convergence of the interval [X_LOWER,
      X_UPPER] with absolute error EPSABS and relative error EPSREL.
      The test returns `GSL_SUCCESS' if the following condition is

--- a/pygsl/multifit.py
+++ b/pygsl/multifit.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""
+r"""
    The functions described in this section perform least-squares fits
 to a general linear model, y = X c where y is a vector of n
 observations, X is an n by p matrix of predictor variables, and c are
@@ -72,7 +72,7 @@ class linear_workspace(_workspace):
         self._ptr = self._alloc(n, p)
 
 def linear(X, y, work=None):
-    """
+    r"""
     This function computes the best-fit parameters C of the model y =
     X c for the observations Y and the matrix of predictor variables
     X.  The variance-covariance matrix of the model parameters COV is
@@ -112,7 +112,7 @@ def linear_usvd(X, y, tol, work=None):
     return _callback.gsl_multifit_linear_usvd(X, y, tol, work._ptr)
     
 def wlinear(X, w, y, work=None):
-    """
+    r"""
     This function computes the best-fit parameters C of the model y =
     X c for the observations Y and the matrix of predictor variables
     X.  The covariance matrix of the model parameters COV is estimated

--- a/pygsl/multiminimize.py
+++ b/pygsl/multiminimize.py
@@ -215,7 +215,7 @@ if _t_type:
         type = _t_type
     
 def test_gradient(g, epsabs):
-    """
+    r"""
     This function tests the norm of the gradient  against the
     absolute tolerance epsabs. The gradient of a multidimensional
     function goes to zero at a minimum. The test returns `GSL_SUCCESS'

--- a/pygsl/multiroots.py
+++ b/pygsl/multiroots.py
@@ -87,7 +87,7 @@ def test_delta(dx, x, epsabs, epsrel):
     return _callback.gsl_multiroot_test_delta(dx, x, epsabs, epsrel)
 
 def test_residual(f, epsabs):
-    """
+    r"""
     This function tests the residual value F against the absolute
      error bound EPSABS.  The test returns `GSL_SUCCESS' if the
      following condition is achieved,
@@ -104,7 +104,7 @@ def test_residual(f, epsabs):
     return _callback.gsl_multiroot_test_residual(f, epsabs)
 
 class dnewton(_fsolver):
-    """
+    r"""
     The "discrete Newton algorithm" is the simplest method of solving a
      multidimensional system.  It uses the Newton iteration
 
@@ -127,7 +127,7 @@ class dnewton(_fsolver):
     type = _callback.cvar.gsl_multiroot_fsolver_dnewton
     
 class broyden(_fsolver):
-    """
+    r"""
     The "Broyden algorithm" is a version of the discrete Newton
      algorithm which attempts to avoids the expensive update of the
      Jacobian matrix on each iteration.  The changes to the Jacobian
@@ -193,7 +193,7 @@ class newton(_fdfsolver):
     type = _callback.cvar.gsl_multiroot_fdfsolver_newton
     
 class gnewton(_fdfsolver):
-    """
+    r"""
         This is a modified version of Newton's method which attempts to
      improve global convergence by requiring every step to reduce the
      Euclidean norm of the residual, |f(x)|.  If the Newton step leads
@@ -208,7 +208,7 @@ class gnewton(_fdfsolver):
     type = _callback.cvar.gsl_multiroot_fdfsolver_gnewton
     
 class hybridj(_fdfsolver):
-    """
+    r"""
     This algorithm is an unscaled version of `hybridsj'.  The steps are
      controlled by a spherical trust region |x' - x| < \delta, instead
      of a generalized region.  This can be useful if the generalized
@@ -218,7 +218,7 @@ class hybridj(_fdfsolver):
     type = _callback.cvar.gsl_multiroot_fdfsolver_hybridj
     
 class hybridsj(_fdfsolver):
-    """
+    r"""
         This is a modified version of Powell's Hybrid method as
      implemented in the HYBRJ algorithm in MINPACK.  Minpack was
      written by Jorge J. More', Burton S. Garbow and Kenneth E.

--- a/pygsl/poly.py
+++ b/pygsl/poly.py
@@ -22,7 +22,7 @@ GSL_FAILURE = pygsl.errno.GSL_FAILURE
 
 
 def poly_eval(*args):
-    """
+    r"""
     This function evaluates the polynomial
     c[0] + c[1] x + c[2] x^2 + \dots + c[len-1] x^{len-1}
     using Horner's method for stability

--- a/pygsl/roots.py
+++ b/pygsl/roots.py
@@ -97,7 +97,7 @@ class _fdfsolver(_fsolver):
         self._isset = 1
         
 def test_interval(x_lower, x_upper, eps_abs, eps_rel):
-    """
+    r"""
      This function tests for the convergence of the interval [X_LOWER,
      X_UPPER] with absolute error EPSABS and relative error EPSREL.
      The test returns `GSL_SUCCESS' if the following condition is
@@ -221,7 +221,7 @@ class newton(_fdfsolver):
     type = _callback.cvar.gsl_root_fdfsolver_newton
 
 class secant(_fdfsolver):
-    """
+    r"""
     The "secant method" is a simplified version of Newton's method does
      not require the computation of the derivative on every step.
 

--- a/pygsl/siman.py
+++ b/pygsl/siman.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Wrapper for the Simulated Annealing Solver provided by GSL.
+r"""Wrapper for the Simulated Annealing Solver provided by GSL.
 
 The  simulated annealing  algorithm  takes random  walks  through the  problem
 space,  looking for  points  with low  energies;  in these  random walks,  the


### PR DESCRIPTION
Python 3.12 issues SyntaxWarning for strings with unrecognized escape characters.  This PR converts such strings to raw strings.  Note that this fixes a few instances of `\t` being interpreted as a tab character, when it was really supposed to be the start of `\tau`, `\times`, or `\to`.