### PR TITLE
Fix line lengths in CREDITS.rst

### DIFF
--- a/CREDITS.rst
+++ b/CREDITS.rst
@@ -29,7 +29,7 @@ Achim, Pierre, c Module
 Test
 
 rng distributions:
------------------
+------------------
 Achim, Pierre, c Module
 
 histogram:
@@ -65,17 +65,17 @@ Pierre, c Module swig, python class
 Test
 
 permutation:
------------
+------------
 Fabian, c Module swig
 Test
 
 blas, linalg, eigen:
--------------------
+--------------------
 Fabian
 Test
 
 numerical integration:
----------------------
+----------------------
 Pierre c Module swig, python class
 Test
 
@@ -97,12 +97,12 @@ multimin:
 Achim, c Module
 
 odeiv:
------
+------
 Pierre, swig
 Test
 
 interpolation:
--------------
+--------------
 Pierre, swig
 Test
 
@@ -115,7 +115,7 @@ Chebyshev Approximations:
 Pierre, swig
 
 One dim Minimization:
---------------------
+---------------------
 Pierre, swig
 Test
 


### PR DESCRIPTION
Processing CREDITS.rst with any rst tools generates warnings of this form:
```
CREDITS.rst:32: (WARNING/2) Title underline too short.
rng distributions:
-----------------
```
Several title underlines are 1 character too short.