### PR TITLE
[FIX] check if jacobian is defined: passing correct pointer

### DIFF
--- a/src/callback/gsl_odeiv2.i
+++ b/src/callback/gsl_odeiv2.i
@@ -100,7 +100,7 @@ struct _pygsl_odeiv2_steppers_require_jacobian{
 	int requires_jacobian;
 };
 
-static int _pygsl_odeiv2_check_step_jacobian(const pygsl_odeiv2_step *step, const pygsl_odeiv2_system *sys)
+static int _pygsl_odeiv2_check_step_jacobian(const pygsl_odeiv2_step *step, const gsl_odeiv2_system *dydt)
 {
 
 	int line = __LINE__, status = GSL_EFAILED;
@@ -149,7 +149,7 @@ static int _pygsl_odeiv2_check_step_jacobian(const pygsl_odeiv2_step *step, cons
 		/*
 		 * so this function requires an jacobian ....
 		 */
-		if(sys->dydt.jacobian){
+		if(dydt->jacobian){
 			/* one found ... goood */
 			DEBUG_MESS(2, "Stepper %s  requires jacobian, one found!",
 				   gsl_odeiv2_step_name(step));
@@ -312,7 +312,7 @@ typedef struct{
 
 		FUNC_MESS_BEGIN();
 
-		flag = _pygsl_odeiv2_check_step_jacobian(self, dydt);
+		flag = _pygsl_odeiv2_check_step_jacobian(self, &dydt->dydt);
 		if(GSL_SUCCESS != PyGSL_ERROR_FLAG(flag)){
 			line = __LINE__ - 2; goto fail;
 		}
@@ -618,7 +618,7 @@ typedef struct{
 			line = __LINE__ - 2; goto fail;
 		}
 
-		status = _pygsl_odeiv2_check_step_jacobian(step, sys);
+		status = _pygsl_odeiv2_check_step_jacobian(step, &sys->dydt);
 		if(GSL_SUCCESS != PyGSL_ERROR_FLAG(status)){
 			line = __LINE__ - 2; goto fail;
 		}


### PR DESCRIPTION
The function that was checking if the stepper had a Jacobian defined as required was using pygsl_odeiv2_system instead of gsl_odeiv2_system. 

gsl_odeiv2_system is sufficient for the function to complete the job, so it was changed to this one.