### PR TITLE
[TASK] support testing versus functionality not provided by debian pa…

### DIFF
--- a/.github/actions/build-deb/action.yml
+++ b/.github/actions/build-deb/action.yml
@@ -1,0 +1,85 @@
+name: "Build Library"
+description: "Common steps for caching, downloading, building, and uploading a library artifact"
+
+inputs:
+  name:
+    description: "Name of the library (for logging)"
+    required: true
+  artifactName:
+    description: "Artifact name to download and upload"
+    required: true
+  cachePath:
+    description: "File or directory to cache (e.g. built artifact)"
+    required: true
+  sourceDownloadScript:
+    description: "Script to download and extract the source"
+    required: true
+  sourceTar:
+    description: "Source tar file to extract"
+    required: true
+  buildCommands:
+    description: "Build commands to run (multiple lines supported)"
+    required: true
+  uploadPaths:
+    description: "Path(s) of the built artifact(s) to upload"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cache library artifact
+      id: cache-artifact
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.cachePath }}
+        key: ${{ inputs.artifactName }}-${{ runner.os }}-${{ hashFiles(inputs.sourceTar, inputs.sourceDownloadScript) }}
+        restore-keys: |
+          ${{ inputs.artifactName }}-${{ runner.os }}-*
+          ${{ inputs.artifactName }}-*
+
+    - name: Download library artifact
+      id: download-artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.artifactName }}
+        path: deb/
+      continue-on-error: True
+
+    - name: Check for library artifact
+      id: artifact-check
+      shell: bash
+      run: |
+        mkdir -p deb/ #  todo: remove this command, should only be required for building the library
+        find . -name '*.deb'
+        if [ -f "${{ inputs.cachePath }}" ]; then
+          echo "${{ inputs.name }} artifact exists"
+          echo "artifact_exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "${{ inputs.name }} artifact needs to be built"
+          echo "artifact_exists=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Display artifact status
+      shell: bash
+      run: |
+        echo "${{ inputs.name }} cache hit: ${{ steps.cache-artifact.outputs.cache-hit }}"
+        echo "${{ inputs.name }} artifact exists: ${{ steps.artifact-check.outputs.artifact_exists }}"
+
+    - name: Download and extract source
+      if: ${{ steps.cache-artifact.outputs.cache-hit != 'true' && steps.artifact-check.outputs.artifact_exists != 'true' }}
+      shell: bash
+      run: |
+        sh -x ${{ inputs.sourceDownloadScript }}
+        mkdir -p build/src && tar -xvf ${{ inputs.sourceTar }} -C build/src --strip-components=1
+
+    - name: Build library
+      shell: bash
+      if: ${{ steps.cache-artifact.outputs.cache-hit != 'true' && steps.artifact-check.outputs.artifact_exists != 'true' }}
+      run: |
+        ${{ inputs.buildCommands }}
+
+    - name: Upload library artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifactName }}
+        path: ${{ inputs.uploadPaths }}

--- a/.github/actions/test-artifact/action.yaml
+++ b/.github/actions/test-artifact/action.yaml
@@ -1,0 +1,50 @@
+name: "Test Artifact"
+description: "Reusable steps for installing an artifact and running tests"
+
+inputs:
+  artifactName:
+    description: "Cache key to use for downloading the artifact"
+    required: true
+  installCommand:
+    description: "Shell command to install the artifact"
+    required: true
+  dependencies:
+    description: "Space-separated apt packages to install"
+    required: true
+  testCommand:
+    description: "Command to run the tests (defaults to running pytest)"
+    default: "(cd tests && python3 -m pytest .)"
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Download build artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.artifactName }}
+        path: deb/
+
+    - name: Install artifact
+      shell: bash
+      run: |
+        find . -type f
+        find . -name '*.deb'
+        ${{ inputs.installCommand }}
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ${{ inputs.dependencies }}
+
+    - name: Setup Python environment and run tests
+      shell: bash
+      run: |
+        python3 -m venv venv-test
+        source venv-test/bin/activate
+        python3 -m pip install --upgrade pip wheel pytest
+        python3 -m pip install .
+        ${{ inputs.testCommand }}

--- a/.github/workflows/pygsl-ci-compat.yml
+++ b/.github/workflows/pygsl-ci-compat.yml
@@ -6,17 +6,17 @@
 
 name: test if pygsl is compatible with swig-4.3 and gsl-2.8
 
-
 on:
   push:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
-
 jobs:
-  build:
+  build-swig-add:
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_RUNNER_DEBUG: true
 
     steps:
       - name: Checkout repository
@@ -27,131 +27,98 @@ jobs:
           sudo apt-get update
           sudo apt-get install dpkg-dev
 
-      - name: Download and extract swig-4.3 source
-        run: |
-          sh -x compat/download-swig4.3.sh
-          mkdir -p build/src && tar -xvf swig4.3_ubuntu_src.tar -C build/src --strip-components=1
-
-      - name: Cache built swig-4.3
-        id: cache-swig-deb
-        uses: actions/cache@v4
+      - name: Build swig 4.3
+        uses: ./.github/actions/build-deb
         with:
-          path: ${{ github.workspace }}/swig4.3_arch.deb
-          key: deb-swig-${{ runner.os }}-v4.3-${{ hashFiles('**/swig4.3_ubuntu_src.tar', 'compat/download-swig4.3.sh') }}
-          restore-keys: |
-            deb-swig-${{ runner.os }}-v4.3
+          name: "Swig 4.3"
+          artifactName: "swig-4.3"
+          # need not be a dir here, but for consistency to other build/test steps
+          cachePath: ${{ github.workspace }}/deb/
+          sourceDownloadScript: "compat/download-swig4.3.sh"
+          sourceTar: "swig4.3_ubuntu_src.tar"
+          buildCommands: |
+            mkdir -p deb/
+            (cd build && dpkg-source -x src/swig*.dsc)
+            (cd build/swig-4.3.0 && sudo apt-get build-dep . && dpkg-buildpackage -us -uc)
+            mv build/swig_4.3.0-1_amd64.deb ${{ github.workspace }}/deb/swig4.3_arch.deb
+            touch ${{ github.workspace }}/deb/swig4.3_arch.deb
+            find . -name '*.deb'
+          uploadPaths: |
+            ${{ github.workspace }}/deb/swig4.3_arch.deb
 
-      - name: Install build dependencies and build swig 4.3
-        if: steps.cache-swig-deb.outputs.cache-hit != 'true'
-        run: |
-          find . -name '*.dsc'
-          cat build/src/swig*.dsc || echo "swig src dsc fails"
-          (cd build && dpkg-source -x src/swig*.dsc)
-          (cd build/swig-4.3.0/ && sudo apt-get build-dep . && dpkg-buildpackage -us -uc )
-          mv build/swig_4.3.0-1_amd64.deb ${{ github.workspace }}/swig4.3_arch.deb
+  build-gsl-add:
+    runs-on: ubuntu-latest
+    env:
+      ACTIONS_RUNNER_DEBUG: true
 
-      - name: Upload package artifact
-        uses: actions/upload-artifact@v4
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build gsl 2.8
+        uses: ./.github/actions/build-deb
         with:
-          name: swig4.3
-          path: ${{ github.workspace }}/swig4.3_arch.deb
+          name: "GSL 2.8"
+          artifactName: "gsl-2.8"
+          # must be dir, more than one file
+          cachePath: ${{ github.workspace }}/deb/
+          sourceDownloadScript: "compat/download-gsl-2.8.sh"
+          sourceTar: "gsl2.8_ubuntu_src.tar"
+          buildCommands: |
+            mkdir -p deb/
+            (cd build && dpkg-source -x src/gsl*.dsc)
+            (cd build/gsl-2.8+dfsg && sudo apt-get build-dep . && dpkg-buildpackage -us -uc)
+            mv build/libgsl28_2.8+dfsg-3ubuntu3_amd64.deb     ${{ github.workspace }}/deb/libgsl_2.8_arch.deb
+            mv build/libgsl-dev_2.8+dfsg-3ubuntu3_amd64.deb   ${{ github.workspace }}/deb/libgsl-dev-2.8_arch.deb
+            mv build/libgslcblas0_2.8+dfsg-3ubuntu3_amd64.deb ${{ github.workspace }}/deb/libgslcblas0-2.8_arch.deb
+            mv build/gsl-bin_2.8+dfsg-3ubuntu3_amd64.deb      ${{ github.workspace }}/deb/gsl-bin_2.8_arch.deb
+            # touch ${{ github.workspace }}/deb/libgsl_2.8_arch.deb
+            # touch ${{ github.workspace }}/deb/libgsl-dev-2.8_arch.deb
+            # touch ${{ github.workspace }}/deb/libgslcblas0-2.8_arch.deb
+            # touch ${{ github.workspace }}/deb/gsl-bin_2.8_arch.deb
+            find . -name '*.deb'
+            ls -l ${{ github.workspace }}/deb/libgsl_2.8_arch.deb
+            ls -l ${{ github.workspace }}/deb/libgsl-dev-2.8_arch.deb
+            ls -l ${{ github.workspace }}/deb/libgslcblas0-2.8_arch.deb
+            ls -l ${{ github.workspace }}/deb/gsl-bin_2.8_arch.deb
+          uploadPaths: |
+            ${{ github.workspace }}//deb/libgsl_2.8_arch.deb
+            ${{ github.workspace }}//deb/libgsl-dev-2.8_arch.deb
+            ${{ github.workspace }}//deb/libgslcblas0-2.8_arch.deb
+            ${{ github.workspace }}//deb/gsl-bin_2.8_arch.deb
 
-      - name: Download and extract gsl-2.8 source
-        run: |
-          sh -x compat/download-gsl-2.8.sh
-          mkdir -p build/src && tar -xvf gsl_2.8_ubuntu_src.tar -C build/src --strip-components=1
-
-      - name: Cache built gsl-2.8
-        id: cache-gsl-deb
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ github.workspace }}/libgsl-dev-2.8_arch.deb
-            ${{ github.workspace }}/libgslcblas0-2.8_arch.deb
-            ${{ github.workspace }}/libgsl_2.8_arch.deb
-          key: deb-gsl-${{ runner.os }}-v2.8-${{ hashFiles('**/gsl_2.8_ubuntu_src.tar', 'compat/download-gsl-2.8.sh') }}
-          restore-keys: |
-            deb-gsl-${{ runner.os }}-v2.8
-            deb-gsl-${{ runner.os }}-v2
-            deb-gsl-${{ runner.os }}-
-
-      - name: Install build dependencies and build package gsl 2.8
-        if: steps.cache-gsl-deb.outputs.cache-hit != 'true'
-        run: |
-          (cd build && dpkg-source -x src/gsl*.dsc)
-          (cd build/gsl-2.8+dfsg/ && sudo apt-get build-dep . && dpkg-buildpackage -us -uc )
-          mv build/libgsl-dev_2.8+dfsg-3ubuntu3_amd64.deb ${{ github.workspace }}/libgsl-dev-2.8_arch.deb
-          mv build/libgslcblas0_2.8+dfsg-3ubuntu3_amd64.deb ${{ github.workspace }}/libgslcblas0-2.8_arch.deb
-          mv build/libgsl28_2.8+dfsg-3ubuntu3_amd64.deb  ${{ github.workspace }}/libgsl_2.8_arch.deb
-
-      - name: Upload gsl 2.8 artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: gsl-2.8
-          path: |
-            ${{ github.workspace }}/libgsl-dev-2.8_arch.deb
-            ${{ github.workspace }}/libgslcblas0-2.8_arch.deb
-            ${{ github.workspace }}/libgsl_2.8_arch.deb
-
-  # test against swig4.3: at current state not part of ubuntu (swig4.0 standard)
   test-swig-additional:
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-swig-add
+
+    env:
+      ACTIONS_RUNNER_DEBUG: true
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download swig4.3 build artifact
-        uses: actions/download-artifact@v4
+      - name: Test swig 4.3
+        uses: ./.github/actions/test-artifact
         with:
-          name: swig4.3
+          artifactName: swig-4.3
+          installCommand: "sudo dpkg -i deb/swig4.3_arch.deb"
+          dependencies: "libgsl-dev python3-dev python3-pip python3-venv"
 
-      - name: Install swig4.3
-        run: |
-          sudo dpkg -i swig4.3_arch.deb || sudo apt-get install -f -y
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install libgsl-dev python3-dev python3-pip python3-venv
-
-      - name: Build and test pygsl
-        run: |
-          python3 -m venv venv-test
-          source venv-test/bin/activate
-          python3 -m pip install --upgrade pip wheel pytest
-          python3 -m pip install .
-          (cd tests && python3 -m pytest .)
-
-  # test against gsl-2.8, at current stage not part of ubuntu (2.7 standard)
-  test-gsl-add:
+  test-gsl-additional:
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-gsl-add
+
+    env:
+      ACTIONS_RUNNER_DEBUG: true
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download gsl 2.8 artifact
-        uses: actions/download-artifact@v4
+      - name: Test gsl 2.8
+        uses: ./.github/actions/test-artifact
         with:
-          name: gsl-2.8
-
-# Let install step fail if it is not there
-      - name: Install gsl-2.8
-        run: |
-          sudo dpkg -i libgsl-dev-2.8_arch.deb libgslcblas0-2.8_arch.deb libgsl_2.8_arch.deb  || sudo apt-get install -f -y
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install swig python3-dev python3-pip python3-venv
-
-      - name: Build and test pygsl
-        run: |
-          python3 -m venv venv-test
-          source venv-test/bin/activate
-          python3 -m pip install --upgrade pip wheel pytest
-          python3 -m pip install .
-          (cd tests && python3 -m pytest .)
+          artifactName: gsl-2.8
+          installCommand: "sudo dpkg -i deb/libgsl-dev-2.8_arch.deb deb/libgslcblas0-2.8_arch.deb deb/libgsl_2.8_arch.deb"
+          dependencies: "swig python3-dev python3-pip python3-venv"

--- a/compat/download-gsl-2.8.sh
+++ b/compat/download-gsl-2.8.sh
@@ -18,4 +18,4 @@ curl -O -s $ORIG
 curl -O -s $DEB_PATCH
 
 cd "$save_path"
-tar -cvf gsl_2.8_ubuntu_src.tar -C build gsl_2.8
+tar -cvf gsl2.8_ubuntu_src.tar -C build gsl_2.8

--- a/pygsl/_version.py
+++ b/pygsl/_version.py
@@ -1,1 +1,1 @@
-version = "2.6.2"
+version = "2.6.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ['meson-python', 'numpy']
 
 [project]
 name = "pygsl"
-version = "2.6.2"
+version = "2.6.3"
 dependencies = ["numpy", ]
 
 description = "GNU Scientific Library Interface"


### PR DESCRIPTION
…ckages

gsl shall be useable also if some tools functionality changes. Here actions are provided that support to build and test gsl with swig or gsl which are not standard in the ubuntu distribution for testing.

Furthermore the build of the debian packages is cached to avoid unnecessary rebuilds.

Currently used for

* swig 4.3: Swig_AppendOutput call signature changed from swig 4.2 to 4.3
* gsl 2.8: bspline interface changed (in an incompatible) manner