### PR TITLE
Fix mismatched format specifiers

### DIFF
--- a/testing/src/sf/sfmodule_testing.c
+++ b/testing/src/sf/sfmodule_testing.c
@@ -58,8 +58,8 @@ _pygsl_sf_long_to_unsigned_int(long val, unsigned int * result)
 	FUNC_MESS_BEGIN();
 
 	DEBUG_MESS(2, "l-> ui: input %ld", val);
-	DEBUG_MESS(8, "sizeof(unsigned int) = %d sizeof(long) =%d", sizeof(unsigned int), sizeof(long));
-	DEBUG_MESS(8, "UINT_MAX = %u ", UINT_MAX, sizeof(unsigned int), sizeof(long));
+	DEBUG_MESS(8, "sizeof(unsigned int) = %zu sizeof(long) =%zu", sizeof(unsigned int), sizeof(long));
+	DEBUG_MESS(8, "UINT_MAX = %u ", UINT_MAX);
 
 	if (val < 0){
 		status = GSL_EINVAL;
@@ -70,7 +70,7 @@ _pygsl_sf_long_to_unsigned_int(long val, unsigned int * result)
 	else if ((UINT_MAX <  LONG_MAX) && (val > (long) UINT_MAX)){
 		status = GSL_EINVAL;
 		*result = UINT_MAX;
-		DEBUG_MESS(2, "Conversion long-> unsigned int: val %ld > UNIT_MAX = %ld ", val, UINT_MAX);
+		DEBUG_MESS(2, "Conversion long-> unsigned int: val %ld > UNIT_MAX = %u ", val, UINT_MAX);
 	}
 	else {
 		status = GSL_SUCCESS;


### PR DESCRIPTION
Fixes these warnings:
```
  In file included from ../Include/pygsl/error_helpers.h:8,
                   from ../testing/src/sf/sfmodule_testing.c:6:
  ../testing/src/sf/sfmodule_testing.c: In function ‘_pygsl_sf_long_to_unsigned_int’:
  ../Include/pygsl/utils.h:48:9: warning: format ‘%d’ expects argument of type ‘int’, but argument 6 has type ‘long unsigned int’ [-Wformat=]
     48 |         "In Function %s from File %s at line %d "  mess      "\n" ,  \
        |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ../testing/src/sf/sfmodule_testing.c:61:9: note: in expansion of macro ‘DEBUG_MESS’
     61 |         DEBUG_MESS(8, "sizeof(unsigned int) = %d sizeof(long) =%d", sizeof(unsigned int), sizeof(long));
        |         ^~~~~~~~~~
  ../Include/pygsl/utils.h:48:9: warning: format ‘%d’ expects argument of type ‘int’, but argument 7 has type ‘long unsigned int’ [-Wformat=]
     48 |         "In Function %s from File %s at line %d "  mess      "\n" ,  \
        |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ../testing/src/sf/sfmodule_testing.c:61:9: note: in expansion of macro ‘DEBUG_MESS’
     61 |         DEBUG_MESS(8, "sizeof(unsigned int) = %d sizeof(long) =%d", sizeof(unsigned int), sizeof(long));
        |         ^~~~~~~~~~
  ../Include/pygsl/utils.h:48:9: warning: too many arguments for format [-Wformat-extra-args]
     48 |         "In Function %s from File %s at line %d "  mess      "\n" ,  \
        |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ../testing/src/sf/sfmodule_testing.c:62:9: note: in expansion of macro ‘DEBUG_MESS’
     62 |         DEBUG_MESS(8, "UINT_MAX = %u ", UINT_MAX, sizeof(unsigned int), sizeof(long));
        |         ^~~~~~~~~~
  ../Include/pygsl/utils.h:48:9: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 7 has type ‘unsigned int’ [-Wformat=]
     48 |         "In Function %s from File %s at line %d "  mess      "\n" ,  \
        |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ../testing/src/sf/sfmodule_testing.c:73:17: note: in expansion of macro ‘DEBUG_MESS’
     73 |                 DEBUG_MESS(2, "Conversion long-> unsigned int: val %ld > UNIT_MAX = %ld ", val, UINT_MAX);
        |                 ^~~~~~~~~~
```
