### PR TITLE
Typo fix: set_avmax -> get_avmax

### DIFF
--- a/src/callback/gsl_multilarge_nlinear.i
+++ b/src/callback/gsl_multilarge_nlinear.i
@@ -475,7 +475,7 @@ typedef struct {
     double get_factor_down(void) {
 	return self->factor_down;
     }
-    double set_avmax(void) {
+    double get_avmax(void) {
 	return self->avmax;
     }
     double get_h_df(void){


### PR DESCRIPTION
Fix a typo that leaves `get_avmax` undefined in `gsl_multilarge_nlinear_parameters`, and provides overloaded definitions of `set_avmax`.  Note that swig warns about this:
```
  ../src/callback/gsl_multilarge_nlinear.i:465: Warning 511: Can't use keyword arguments with overloaded functions (gsl_multilarge_nlinear_parameters::set_avmax(double const)).
```
