### PR TITLE
Avoid nonexistent const gsl_vector * typemap

### DIFF
--- a/src/callback/gsl_multilarge_nlinear.i
+++ b/src/callback/gsl_multilarge_nlinear.i
@@ -614,7 +614,7 @@ typedef struct {
 }
 
 
-%apply const gsl_vector *IN {const gsl_vector * weights};
+%apply gsl_vector *IN {const gsl_vector * weights};
 
 %extend pygsl_multilarge_nlinear_workspace{
     pygsl_multilarge_nlinear_workspace(


### PR DESCRIPTION
I saw this warning in the build log, with swig 4.3.1 on a Fedora Rawhide machine:
```
  ../src/callback/gsl_multilarge_nlinear.i:617: Warning 453: Can't apply (gsl_vector const *IN). No typemaps are defined.
```
The issue appears to be that only a non-const `gsl_vector *` typemap is defined in `typemaps/gsl_block_typemaps.i`.  This change gets rid of the warning.