### PR TITLE
Remove duplicate definition of eval_deriv2_vector

### DIFF
--- a/src/gslwrap/interpolation.i
+++ b/src/gslwrap/interpolation.i
@@ -411,10 +411,6 @@ struct pygsl_spline{
 	  return  _pygsl_spline_eval_vector_generic(self->spline, IN, self->acc, gsl_spline_eval_deriv);
      }
 
-     PyObject * eval_deriv2_vector(const gsl_vector *IN){
-	  return  _pygsl_spline_eval_vector_generic(self->spline, IN, self->acc, gsl_spline_eval_deriv2);
-     }
-
      PyObject * eval_deriv_e_vector(const gsl_vector *IN){
 	  return  _pygsl_spline_eval_e_vector_generic(self->spline, IN, self->acc, gsl_spline_eval_deriv_e);
      }


### PR DESCRIPTION
There are two identical definitions of `eval_deriv2_vector`, leading swig to warn:
```
  ../src/gslwrap/interpolation.i:424: Warning 322: Redundant redeclaration of identifier 'eval_deriv2_vector' as pygsl_spline::eval_deriv2_vector(gsl_vector const *) ignored,
  ../src/gslwrap/interpolation.i:416: Warning 322: previous declaration of 'eval_deriv2_vector' as pygsl_spline::eval_deriv2_vector(gsl_vector const *).
```
