### PR TITLE
Use swig python3 macros instead of python2

### DIFF
--- a/Include/pygsl/error_helpers.h
+++ b/Include/pygsl/error_helpers.h
@@ -108,7 +108,7 @@ PyGSL_warning(const char *, const char*, int, int);
                      PyGSL_error_flag_to_pyint((long) (flag))
 #else /* PyGSL_PY3K */
 #define PyGSL_ERROR_FLAG_TO_PYINT(flag)                                     \
-(((long) flag <= 0) && (!PyErr_Occurred())) ? PyInt_FromLong((long) flag) : \
+(((long) flag <= 0) && (!PyErr_Occurred())) ? PyLong_FromLong((long) flag) : \
                      PyGSL_error_flag_to_pyint((long) (flag))
 #endif /* PyGSL_PY3K */
 

--- a/Include/pygsl/general_helpers.h
+++ b/Include/pygsl/general_helpers.h
@@ -113,9 +113,9 @@ PyGSL_clear_name(char *name, int size);
   :  PyGSL_pyint_to_int((object),  (result), (info))  
 #else /* PyGSL_PY3K */
 #define PyGSL_PYINT_TO_INT(object, result, info)        \
-  ( PyInt_Check((object)) )                               \
+  ( PyLong_Check((object)) )                               \
   ?                                                        \
-   ((*(result))   = (int) PyInt_AsLong((object)), GSL_SUCCESS) \
+   ((*(result))   = (int) PyLong_AsLong((object)), GSL_SUCCESS) \
   :  PyGSL_pyint_to_int((object),  (result), (info))  
 #endif /* PyGSL_PY3K */
 

--- a/src/callback/function_helpers_multifit_nlinear.ic
+++ b/src/callback/function_helpers_multifit_nlinear.ic
@@ -230,7 +230,7 @@ PyGSL_multifitorlarge_nlinear_driver_callback(const size_t iter, pygsl_multifito
 	 goto fail;
      }
 
-     niter_o = PyInt_FromLong((long) iter);
+     niter_o = PyLong_FromLong((long) iter);
      if(!niter_o){
 	 goto fail;
      }

--- a/src/callback/gsl_multilarge_nlinear.i
+++ b/src/callback/gsl_multilarge_nlinear.i
@@ -136,7 +136,7 @@ _pygsl_multilarge_nlinear_df (CBLAS_TRANSPOSE_t TransJ, const gsl_vector * x, co
 	  trb_lineno = __LINE__ - 2;
 	  goto fail;
     }
-    transj_o = PyInt_FromLong((long) TransJ);
+    transj_o = PyLong_FromLong((long) TransJ);
     if(transj_o == NULL){
 	  trb_lineno = __LINE__ - 2;
 	  goto fail;

--- a/src/diffmodule.c
+++ b/src/diffmodule.c
@@ -93,7 +93,7 @@ DL_EXPORT(void) initdiff(void)
 	if (dict == NULL)
 		return;
 	
-	if (!(item = PyString_FromString(diff_module_doc))){
+	if (!(item = PyUnicode_FromString(diff_module_doc))){
 		PyErr_SetString(PyExc_ImportError, 
 				"I could not generate module doc string!");
 		return;

--- a/src/gslwrap/combination.i
+++ b/src/gslwrap/combination.i
@@ -68,7 +68,7 @@ struct gsl_combination_struct
        if (a_list == NULL)
 	    return NULL;
        for(i=0; i<size; i++){
-	    a_int = PyInt_FromLong((long) gsl_combination_get(self, i));
+	    a_int = PyLong_FromLong((long) gsl_combination_get(self, i));
 	    if (a_int == NULL){
 		 Py_DECREF(a_list);
 		 return NULL;

--- a/src/gslwrap/permutation.i
+++ b/src/gslwrap/permutation.i
@@ -93,7 +93,7 @@
        if (a_list == NULL)
 	    return NULL;
        for(i=0; i<size; i++){
-	    a_int = PyInt_FromLong((long) gsl_permutation_get(self, i));
+	    a_int = PyLong_FromLong((long) gsl_permutation_get(self, i));
 	    if (a_int == NULL){
 		 Py_DECREF(a_list);
 		 return NULL;

--- a/src/histogram/histogram.ic
+++ b/src/histogram/histogram.ic
@@ -392,7 +392,7 @@ histogram_histogram_mp_subscript(PyObject *self, PyObject *key)
   /* get key */
   my_key=PyNumber_Long(key);
   if (my_key==NULL) return NULL;
-  k=PyInt_AsLong(my_key);
+  k=PyLong_AsLong(my_key);
   if (k<0 || k>=histogram->n) {
     pygsl_error ("index lies outside valid range of 0 .. n - 1",
 	       filename, __LINE__, GSL_EDOM );
@@ -419,7 +419,7 @@ histogram_histogram_mp_ass_subscript(PyObject *self, PyObject *key, PyObject *va
   /* get key */
   my_key=PyNumber_Long(key);
   if (my_key==NULL) return -1;
-  k=PyInt_AsLong(my_key);
+  k=PyLong_AsLong(my_key);
   if (k<0 || k>=histogram->n) {
     pygsl_error ("index lies outside valid range of 0 .. n - 1",
 	       filename, __LINE__, GSL_EDOM);

--- a/src/histogram/histogram_common.ic
+++ b/src/histogram/histogram_common.ic
@@ -171,7 +171,7 @@ FUNCNAME(equal_bins_p)(PyObject *self, PyObject *arg)
   }
 
   result=GSLNAME(equal_bins_p)(histogram,histogram2);
-  return PyInt_FromLong(result);
+  return PyLong_FromLong(result);
 }
 
 static void

--- a/src/init/block_helpers.c
+++ b/src/init/block_helpers.c
@@ -284,7 +284,7 @@ PyGSL_PyArray_Check(PyArrayObject *a_array, int array_type, int flag,  int nd,
 #ifdef PyGSL_PY3K
 #define _PyGSL_WRAP_LONG_FROM_PyObject(src) PyLong_AS_LONG(((src)))
 #else
-#define _PyGSL_WRAP_LONG_FROM_PyObject(src) ( PyInt_AsLong(((src))) )
+#define _PyGSL_WRAP_LONG_FROM_PyObject(src) ( PyLong_AsLong(((src))) )
 #endif
 
 static PyArrayObject *

--- a/src/multiminmodule.c
+++ b/src/multiminmodule.c
@@ -177,7 +177,7 @@ static PyObject* multimin_multimin_iterate(PyObject *self,
     PyErr_SetString(PyExc_RuntimeError,"no function specified!");
     return NULL;
   }
-  return PyInt_FromLong(gsl_multimin_fminimizer_iterate(((multimin_multiminObject*)self)->min));
+  return PyLong_FromLong(gsl_multimin_fminimizer_iterate(((multimin_multiminObject*)self)->min));
 }
 
 static PyObject* multimin_multimin_x(PyObject *self,

--- a/src/qrngmodule.c
+++ b/src/qrngmodule.c
@@ -14,8 +14,8 @@ static PyObject *module = NULL;
 #define PyGSL_STRING_AS_STRING(obj) PyBytes_FromString(obj)
 #define PyGSL_STRING_LENGTH(obj)      PyBytes_Length(obj)
 #else
-#define PyGSL_STRING_AS_STRING(obj) PyString_AsString(obj)
-#define PyGSL_STRING_LENGTH(obj)      PyString_Size(obj)
+#define PyGSL_STRING_AS_STRING(obj) PyBytes_AsString(obj)
+#define PyGSL_STRING_LENGTH(obj)      PyBytes_Size(obj)
 #endif
 
 

--- a/src/sfmodule.c
+++ b/src/sfmodule.c
@@ -40,7 +40,7 @@ int eval_gsl_mode_char(gsl_mode_t* mode, char mode_char) {
   gsl_error_dict=PyModule_GetDict(gsl_error_module);
   gsl_error_object=PyDict_GetItemString(gsl_error_dict,"gsl_Error");
   PyErr_SetObject(gsl_error_object,
-		  PyString_FromString(error_text));
+		  PyUnicode_FromString(error_text));
 
   return -1;
 }

--- a/src/statistics/charmodule.c
+++ b/src/statistics/charmodule.c
@@ -23,7 +23,7 @@
 #define STATMOD_APPEND_PYC_TYPE(X) X ## BYTE
 
 #define STATMOD_FUNC_EXT(X, Y) X ## _char ## Y
-#define STATMOD_PY_AS_C PyInt_AsLong
+#define STATMOD_PY_AS_C PyLong_AsLong
 #define STATMOD_C_TYPE char
 #include "functions.c"
 

--- a/src/statistics/intmodule.c
+++ b/src/statistics/intmodule.c
@@ -20,7 +20,7 @@
 #define STATMOD_APPEND_PY_TYPE(X) X ## Int
 #define STATMOD_APPEND_PYC_TYPE(X) X ## INT
 #define STATMOD_FUNC_EXT(X, Y) X ## _int ## Y
-#define STATMOD_PY_AS_C PyInt_AsLong
+#define STATMOD_PY_AS_C PyLong_AsLong
 #define STATMOD_C_TYPE int
 #define PyGSL_STATISTICS_IMPORT_API
 #include "functions.c"

--- a/src/statistics/longmodule.c
+++ b/src/statistics/longmodule.c
@@ -20,7 +20,7 @@
 #define STATMOD_APPEND_PY_TYPE(X) X ## Int
 #define STATMOD_APPEND_PYC_TYPE(X) X ## LONG
 #define STATMOD_FUNC_EXT(X, Y) X ## _long ## Y
-#define STATMOD_PY_AS_C PyInt_AsLong
+#define STATMOD_PY_AS_C PyLong_AsLong
 #define STATMOD_C_TYPE long int
 #include "functions.c"
 

--- a/src/statistics/shortmodule.c
+++ b/src/statistics/shortmodule.c
@@ -19,7 +19,7 @@
 #define STATMOD_APPEND_PY_TYPE(X) X ## Int
 #define STATMOD_APPEND_PYC_TYPE(X) X ## SHORT
 #define STATMOD_FUNC_EXT(X, Y) X ## _short ## Y
-#define STATMOD_PY_AS_C PyInt_AsLong
+#define STATMOD_PY_AS_C PyLong_AsLong
 #define STATMOD_C_TYPE short int
 #include "functions.c"
 

--- a/src/statistics/ucharmodule.c
+++ b/src/statistics/ucharmodule.c
@@ -19,7 +19,7 @@
 #define STATMOD_APPEND_PY_TYPE(X) X ## Int
 #define STATMOD_APPEND_PYC_TYPE(X) X ## UBYTE
 #define STATMOD_FUNC_EXT(X, Y) X ## _uchar ## Y
-#define STATMOD_PY_AS_C PyInt_AsLong
+#define STATMOD_PY_AS_C PyLong_AsLong
 #define STATMOD_C_TYPE unsigned char
 #include "functions.c"
 

--- a/testing/src/multiminmodule.c
+++ b/testing/src/multiminmodule.c
@@ -566,7 +566,7 @@ PyGSL_multimin_istype(PyGSL_multimin *self, PyObject *args)
 	  p = fdf;
      }
      FUNC_MESS_END();
-     return PyString_FromString(p);
+     return PyUnicode_FromString(p);
 }
 
 static PyObject* 

--- a/testing/src/solvers/minimize.c
+++ b/testing/src/solvers/minimize.c
@@ -60,7 +60,7 @@ PyGSL_min_solver_test_interval(PyGSL_solver * self, PyObject *args)
      gsl_min_fminimizer *s = (gsl_min_fminimizer *) self->solver;
      if(!PyArg_ParseTuple(args, "dd", &epsabs, &epsrel))
 	  return NULL;
-     return PyInt_FromLong(gsl_min_test_interval(s->x_lower, s->x_upper, epsabs, epsrel));
+     return PyLong_FromLong(gsl_min_test_interval(s->x_lower, s->x_upper, epsabs, epsrel));
 }
 
 
@@ -126,7 +126,7 @@ PyGSL_min_test_interval(PyObject * self, PyObject *args)
      double x_lower, x_upper, epsabs, epsrel;
      if(!PyArg_ParseTuple(args, "dddd", &x_lower, &x_upper, &epsabs, &epsrel))
 	  return NULL;
-     return PyInt_FromLong(gsl_min_test_interval(x_lower, x_upper, epsabs, epsrel));
+     return PyLong_FromLong(gsl_min_test_interval(x_lower, x_upper, epsabs, epsrel));
 }
 
 static const char PyGSL_minimize_module_doc [] = "XXX Missing ";
@@ -155,7 +155,7 @@ initminimize(void)
      if(!dict)
 	  goto fail;
 
-     if (!(item = PyString_FromString((char*)PyGSL_minimize_module_doc))){
+     if (!(item = PyUnicode_FromString((char*)PyGSL_minimize_module_doc))){
 	  PyErr_SetString(PyExc_ImportError, 
 			  "I could not generate module doc string!");
 	  goto fail;

--- a/testing/src/solvers/monte.c
+++ b/testing/src/solvers/monte.c
@@ -505,7 +505,7 @@ initmonte(void)
      assert(PyGSL_API);
 
 
-     if (!(item = PyString_FromString((char*)module_doc))){
+     if (!(item = PyUnicode_FromString((char*)module_doc))){
 	  PyErr_SetString(PyExc_ImportError, 
 			  "I could not generate module doc string!");
 	  goto fail;

--- a/testing/src/solvers/multifit_nlin.c
+++ b/testing/src/solvers/multifit_nlin.c
@@ -335,7 +335,7 @@ initmultifit_nlin(void)
      assert(PyGSL_API);
 
 
-     if (!(item = PyString_FromString((char*)PyGSL_multifit_nlin_module_doc))){
+     if (!(item = PyUnicode_FromString((char*)PyGSL_multifit_nlin_module_doc))){
 	  PyErr_SetString(PyExc_ImportError, 
 			  "I could not generate module doc string!");
 	  goto fail;

--- a/testing/src/solvers/multiroot.c
+++ b/testing/src/solvers/multiroot.c
@@ -308,7 +308,7 @@ initmultiroot(void)
      if(!dict)
 	  goto fail;
 
-     if (!(item = PyString_FromString((char*)PyGSL_multiroot_module_doc))){
+     if (!(item = PyUnicode_FromString((char*)PyGSL_multiroot_module_doc))){
 	  PyErr_SetString(PyExc_ImportError, 
 			  "I could not generate module doc string!");
 	  goto fail;

--- a/typemaps/misc_typemaps.i
+++ b/typemaps/misc_typemaps.i
@@ -13,7 +13,7 @@
 %}
 %typemap(argout) size_t * OUTPUT{
     PyObject *o;
-    o = PyInt_FromLong((long) (*$1));
+    o = PyLong_FromLong((long) (*$1));
     $result = PyGSL_SWIG_Python_AppendOutput($result, o);
 }
 %typemap(in, numinputs=0) size_t * OUT = size_t * OUTPUT;


### PR DESCRIPTION
Swig 4.5.0 has removed the old python2 macros, so pygsl does not compile.  This PR moves to the python3 versions of the macros.  Thanks to Jitka Plesnikova of RedHat for the patch.