### PR TITLE
[Fix] Cast to object pointer to fix build error

### DIFF
--- a/src/transform/arraycopy.c
+++ b/src/transform/arraycopy.c
@@ -410,7 +410,7 @@ PyGSL_Shadow_array(PyObject *shadow, PyObject *master,  enum pygsl_transform_mod
 		goto fail;
 	}
 
-	m = master;
+	m = (PyArrayObject *) master;
 	assert(m);
 	assert(
 	    PyArray_TYPE(m) == PyGSL_TRANSFORM_MODE_SWITCH(mode, NPY_CDOUBLE, NPY_CFLOAT)
@@ -432,7 +432,7 @@ PyGSL_Shadow_array(PyObject *shadow, PyObject *master,  enum pygsl_transform_mod
 		}else{
 			FUNC_MESS("Copying input to output array");
 			/* Check if it is an array of the approbriate size */
-			s = shadow;
+			s = (PyArrayObject *) shadow;
 			if((PyGSL_array_check((PyObject *) s)) && (PyArray_NDIM(s) == 1)
 			   && (PyArray_TYPE(s) == PyArray_TYPE(m))
 			   && (PyArray_DIM(s, 0) == PyArray_DIM(m, 0))){


### PR DESCRIPTION
Build fails due to incompatible pointer type.

```
FAILED: [code=1] src/transform/_transform.cpython-314-x86_64-linux-gnu.so.p/transformmodule.c.o
cc -Isrc/transform/_transform.cpython-314-x86_64-linux-gnu.so.p -Isrc/transform -I../src/transform -I/usr/lib/python3.14/site-packages/numpy/_core/include -IInclude -I../Include -I. -I.. -I/usr/include/python3.14 -fvisibility=hidden -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O0 -g -fPIC -MD -MQ src/transform/_transform.cpython-314-x86_64-linux-gnu.so.p/transformmodule.c.o -MF src/transform/_transform.cpython-314-x86_64-linux-gnu.so.p/transformmodule.c.o.d -o src/transform/_transform.cpython-314-x86_64-linux-gnu.so.p/transformmodule.c.o -c ../src/transform/transformmodule.c
In file included from ../src/transform/transformmodule.c:46:
../src/transform/arraycopy.c: In function ‘PyGSL_Shadow_array’:
../src/transform/arraycopy.c:413:11: error: assignment to ‘PyArrayObject *’ {aka ‘struct tagPyArrayObject *’} from incompatible pointer type ‘PyObject *’ {aka
‘struct _object *’} [-Wincompatible-pointer-types]
  413 |         m = master;
      |           ^
../src/transform/arraycopy.c:435:27: error: assignment to ‘PyArrayObject *’ {aka ‘struct tagPyArrayObject *’} from incompatible pointer type ‘PyObject *’ {aka
‘struct _object *’} [-Wincompatible-pointer-types]
  435 |                         s = shadow;
      |                           ^
```

Casting both `master` & `shadow` to `PyArrayObject *`  solves this.

Regards
-Gil